### PR TITLE
스웨거 문서 추가

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ import cors from 'cors';
 import dotenv from 'dotenv';
 
 import { router } from './src/routes/router.js';
+import { setupSwagger } from './swagger/config.js';
 
 const PORT = 8081;
 
@@ -31,6 +32,9 @@ const createApp = async () => {
   app.get('/', (req, res) => {
     res.send('CLIP 개발용 임시서버입니다.');
   });
+
+  // Swagger 설정 적용
+  setupSwagger(app);
 
   // 라우터 연결
   router(app);

--- a/swagger/_auth.swagger.js
+++ b/swagger/_auth.swagger.js
@@ -100,7 +100,7 @@
  * @swagger
  * /api/auth/refresh:
  *   post:
- *     summary: JWT 재발급 [미구현]
+ *     summary: JWT 재발급
  *     description: 사용자의 토큰을 재발급합니다.
  *     tags: [Auth - 회원 인증 API]
  *
@@ -151,7 +151,7 @@
  *               properties:
  *                 message:
  *                   type: string
- *                   example: "사용할 수 있는 휴대폰번호입니다."
+ *                   example: "사용할 수 있는 닉네임입니다."
  *       400:
  *         content:
  *           application/json:
@@ -160,7 +160,7 @@
  *               properties:
  *                 message:
  *                   type: string
- *                   example: "휴대폰번호 중복확인에 실패하였습니다."
+ *                   example: "닉네임 중복확인에 실패하였습니다."
  *       404:
  *         content:
  *           application/json:
@@ -169,7 +169,7 @@
  *               properties:
  *                 message:
  *                   type: string
- *                   example: "이미 사용중인 휴대폰번호입니다."
+ *                   example: "이미 사용중인 닉네임입니다."
  *
  */
 
@@ -177,7 +177,7 @@
  * @swagger
  * /api/auth/check/duplicateId/{userId}:
  *   post:
- *     summary: 아이디 중복확인 [미구현]
+ *     summary: 아이디 중복확인
  *     description: 회원가입시 아이디 중복확인을 진행합니다.
  *     tags: [Auth - 회원 인증 API]
  *     requestBody:

--- a/swagger/_auth.swagger.js
+++ b/swagger/_auth.swagger.js
@@ -1,0 +1,221 @@
+/**
+ * @swagger
+ * /api/auth/signup:
+ *   post:
+ *     summary: 회원가입
+ *     description: 회원정보를 입력하여 회원가입을 진행합니다.
+ *     tags: [Auth - 회원 인증 API]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               userId:
+ *                 type: string
+ *               password:
+ *                 type: string
+ *               nickname:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "회원가입에 성공하였습니다."
+ *       400:
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "회원가입에 실패하였습니다."
+ *       409:
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "이미 등록된 사용자입니다."
+ */
+
+/**
+ * @swagger
+ * /api/auth/login:
+ *   post:
+ *     summary: 로그인
+ *     description: 아이디와 비밀번호를 입력하여 로그인을 진행합니다.
+ *     tags: [Auth - 회원 인증 API]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               userId:
+ *                 type: string
+ *               password:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "로그인에 성공하였습니다."
+ *       400:
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "로그인에 실패하였습니다."
+ *       404:
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "아이디 또는 비밀번호가 잘못되었습니다."
+ */
+
+/**
+ * @swagger
+ * /api/auth/refresh:
+ *   post:
+ *     summary: JWT 재발급 [미구현]
+ *     description: 사용자의 토큰을 재발급합니다.
+ *     tags: [Auth - 회원 인증 API]
+ *
+ *     responses:
+ *       200:
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "토큰 재발급에 성공하였습니다."
+ *       400:
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "토큰 재발급에 실패하였습니다."
+ *
+ */
+
+/**
+ * @swagger
+ * /api/auth/check/duplicateNickname/{nickname}:
+ *   post:
+ *     summary: 닉네임 중복확인
+ *     description: 닉네임 중복확인을 진행합니다.
+ *     tags: [Auth - 회원 인증 API]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               nickname:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "사용할 수 있는 휴대폰번호입니다."
+ *       400:
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "휴대폰번호 중복확인에 실패하였습니다."
+ *       404:
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "이미 사용중인 휴대폰번호입니다."
+ *
+ */
+
+/**
+ * @swagger
+ * /api/auth/check/duplicateId/{userId}:
+ *   post:
+ *     summary: 아이디 중복확인 [미구현]
+ *     description: 회원가입시 아이디 중복확인을 진행합니다.
+ *     tags: [Auth - 회원 인증 API]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               phoneNumber:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "사용할 수 있는 아이디입니다."
+ *       400:
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "아이디 중복확인에 실패하였습니다."
+ *       404:
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "이미 사용중인 아이디입니다."
+ *
+ */

--- a/swagger/config.js
+++ b/swagger/config.js
@@ -1,0 +1,55 @@
+import swaggerJsdoc from 'swagger-jsdoc';
+import swaggerUi from 'swagger-ui-express';
+
+const options = {
+  definition: {
+    openapi: '3.0.0',
+    info: {
+      title: 'ClipBE-Express',
+      description: 'CLIP 개발용 서버',
+      version: 'v2.0.0',
+    },
+    servers: [
+      {
+        url: 'https://clip-be-express.vercel.app/',
+        description: 'Develop Server',
+      },
+      {
+        url: 'http://localhost:8081/',
+        description: 'Local Server',
+      },
+    ],
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+        },
+      },
+    },
+    security: [
+      {
+        bearerAuth: [],
+      },
+    ],
+  },
+  apis: ['./*.swagger.js', './swagger/*'],
+};
+
+const specs = swaggerJsdoc(options);
+
+export const setupSwagger = (app) => {
+  app.use('/swagger-ui', swaggerUi.serve, swaggerUi.setup(specs));
+
+  // JSON 명세 보기용
+  app.get('/swagger.json', (_, res) => {
+    res.setHeader('Content-Type', 'application/json');
+    res.send(specs);
+  });
+
+  // Redirect /swagger-ui to the Swagger UI
+  app.get('/swagger', (_, res) => {
+    res.redirect('/swagger-ui/');
+  });
+};


### PR DESCRIPTION
## **📝 요약 (Summary)**

프로젝트의 API 명세를 효율적으로 관리하고 팀원들과 공유하기 위해 **Swagger(OpenAPI)**를 도입했습니다. `swagger-jsdoc`과 `swagger-ui-express`를 사용하여 Express 서버에 API 문서 페이지를 구축했으며, 배포 환경에서의 정상 동작을 확인하기 위한 초기 설정을 완료했습니다.

## **✅ 주요 변경 사항 (Key Changes)**

- `swagger-jsdoc`, `swagger-ui-express` 라이브러리 의존성 추가
- Swagger 기본 설정 파일 (`swagger/index.js`) 생성
- JSDoc 주석을 사용한 임시 API 문서 작성 (`/api/auth/...`)
- Express `app.js`에 Swagger UI 미들웨어 연동

## **💻 상세 구현 내용 (Implementation Details)**

**1. API 문서화를 위해 Swagger를 도입한 이유**

**문제점**: 프로젝트가 발전함에 따라 API 엔드포인트가 다양해지고 복잡해질 것을 대비하여, 명확하고 표준화된 API 문서의 필요성이 대두되었습니다.

**해결**: **Swagger(OpenAPI)**는 API의 요청/응답 구조를 명확하게 정의하고, UI를 통해 직접 테스트까지 해볼 수 있는 강력한 기능을 제공하여 개발 생산성과 협업 효율성을 높이기 위해 도입했습니다.

## **🚀 트러블 슈팅 (Trouble Shooting)**

초기 설정 시, JSDoc 주석을 작성했음에도 불구하고 Swagger UI에 API가 제대로 표시되지 않는 문제가 있었습니다. 원인은 `swaggerJsdoc` 옵션의 `apis` 배열에 주석이 담긴 파일들의 경로를 정확하게 명시해주지 않았기 때문이었습니다. `['./src/apis/**/*.js']`와 같이 글로브 패턴을 사용하여 모든 API 핸들러 파일을 포함하도록 수정하여 문제를 해결했습니다.

## **⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)**

- 현재 작성된 API 문서는 배포 환경에서의 렌더링 테스트를 위한 **임시 버전**입니다. 실제 비즈니스 로직이 구현됨에 따라, 모든 API의 요청/응답 스키마를 더 상세하고 정확하게 업데이트해야 합니다.

## **📸 스크린샷 (Screenshots)**
<img width="2032" height="1117" alt="스크린샷 2025-09-19 오전 2 45 56" src="https://github.com/user-attachments/assets/f9d85929-8cb5-4c08-ace7-f21118e95739" />

## **#️⃣ 관련 이슈 (Related Issues)**

- Close #2 