### PR TITLE
Feat#09 token reissue

### DIFF
--- a/src/apis/auth/controller/handleTokenRefresh.js
+++ b/src/apis/auth/controller/handleTokenRefresh.js
@@ -1,0 +1,22 @@
+import { CustomError } from '../../../utils/errors.js';
+import { createErrorResponse, createSuccessResponse } from '../../../utils/responseFormatter.js';
+import { refreshUserSession } from '../service/refreshUserSession.js';
+
+export const handleTokenRefresh = async (req, res) => {
+  try {
+    const { refreshToken } = req.body;
+
+    const newTokens = await refreshUserSession({ refreshToken });
+    const successResponse = createSuccessResponse(newTokens);
+
+    res.status(200).json(successResponse);
+  } catch (error) {
+    if (error instanceof CustomError) {
+      const errorResponse = createErrorResponse(error.name, error.message);
+      res.status(error.statusCode).json(errorResponse);
+    } else {
+      const errorResponse = createErrorResponse('SERVER_ERROR', '서버에서 알 수 없는 오류가 발생했습니다.');
+      res.status(500).json(errorResponse);
+    }
+  }
+};

--- a/src/apis/auth/service/refreshUserSession.js
+++ b/src/apis/auth/service/refreshUserSession.js
@@ -1,0 +1,21 @@
+import { supabase } from '../../../db/supabase-client.js';
+import { CustomError } from '../../../utils/errors.js';
+
+export const refreshUserSession = async ({ refreshToken }) => {
+  if (!refreshToken) {
+    throw new CustomError('리프레시 토큰이 필요합니다.', 400);
+  }
+
+  const { data, error } = await supabase.auth.refreshSession({
+    refresh_token: refreshToken,
+  });
+
+  if (error) {
+    throw new CustomError('유효하지 않은 리프레시 토큰입니다.', 401);
+  }
+
+  return {
+    accessToken: data.session.access_token,
+    refreshToken: data.session.refresh_token,
+  };
+};

--- a/src/routes/router.js
+++ b/src/routes/router.js
@@ -1,3 +1,4 @@
+import { handleTokenRefresh } from '../apis/auth/controller/handleTokenRefresh.js';
 import { handleUserCreate } from '../apis/auth/controller/handleUserCreate.js';
 import { handleUserLogin } from '../apis/auth/controller/handlerUserLogin.js';
 import { handleGetAllClips } from '../apis/clip/controller/handleGetAllClips.js';
@@ -6,4 +7,5 @@ export const router = (app) => {
   app.get('/api/clips', handleGetAllClips);
   app.post('/api/auth/login', handleUserLogin);
   app.post('/api/auth/signup', handleUserCreate);
+  app.post('/api/auth/refresh', handleTokenRefresh);
 };

--- a/swagger/_auth.swagger.js
+++ b/swagger/_auth.swagger.js
@@ -113,7 +113,15 @@
  *     summary: JWT 재발급
  *     description: 사용자의 토큰을 재발급합니다.
  *     tags: [Auth - 회원 인증 API]
- *
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               refreshToken:
+ *                 type: string
  *     responses:
  *       200:
  *         content:


### PR DESCRIPTION
## 📝 요약 (Summary)

사용자 인증의 연속성을 보장하기 위해, **refreshToken**을 사용하여 만료된 **accessToken**을 재발급받는 POST /api/auth/refresh API를 구현했습니다. 또한, 해당 API 명세를 Swagger에 추가하여 팀원들이 쉽게 확인하고 테스트할 수 있도록 문서화했습니다.

## ✅ 주요 변경 사항 (Key Changes)

POST `/api/auth/refresh` 토큰 재발급 API 구현 (Controller, Service 계층)

Supabase의 refreshSession 메소드를 활용한 토큰 재발급 로직 구현

Swagger(JSDoc)에 토큰 재발급 API 명세 추가

## 💻 상세 구현 내용 (Implementation Details)

1. 토큰 재발급 기능을 구현한 이유

문제점: **accessToken**은 수명이 짧아(보통 1시간) 보안에 유리하지만, 만료될 때마다 사용자가 다시 로그인해야 하는 불편함이 있습니다. 이는 사용자 경험(UX)을 크게 저해합니다.

해결: 이 문제를 해결하기 위해, 수명이 긴 **refreshToken**을 도입했습니다. accessToken이 만료되었을 때, 프론트엔드에서는 이 refreshToken을 사용하여 백엔드에 조용히 새로운 accessToken을 요청할 수 있습니다. 이를 통해 사용자는 로그인이 끊기는 경험 없이 서비스를 계속 이용할 수 있습니다.

2. Supabase refreshSession을 활용한 구현 방식

구현: Service 계층에서 `supabase.auth.refreshSession()` 메소드를 사용하여 토큰 재발급 로직을 구현했습니다. 클라이언트로부터 받은 refreshToken을 이 메소드에 전달하면, Supabase가 토큰의 유효성을 검증하고 안전하게 새로운 `accessToken`과 `refreshToken`을 발급해줍니다.

사전 설정: 이 기능의 안정적인 동작을 위해, Supabase 대시보드의 Authentication > Providers > Email 설정에서 'Enable Refresh Token Reuse' 옵션을 활성화했습니다. 이 설정은 토큰 탈취 공격(Replay Attack)에 대한 보안을 강화해줍니다.

## 🚀 트러블 슈팅 (Trouble Shooting)

초기 구현 시, refreshToken이 없거나 유효하지 않은 경우에 대한 에러 처리가 미흡했습니다. 이를 보완하기 위해, Service 계층에서 토큰의 존재 여부를 확인하고, Supabase로부터 받은 인증 에러를 CustomError로 변환하여, Controller에서 400 Bad Request 또는 401 Unauthorized 와 같이 명확한 HTTP 상태 코드로 응답하도록 수정했습니다.

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

현재 클라이언트(프론트엔드)에서는 accessToken 만료 시 자동으로 재발급을 요청하는 로직(예: Axios 인터셉터)이 구현되어 있지 않습니다. 이는 다음 프론트엔드 작업에서 구현될 예정입니다.

## 📸 스크린샷 (Screenshots)
<img width="1392" height="912" alt="스크린샷 2025-09-22 오후 12 35 09" src="https://github.com/user-attachments/assets/be3f9f4e-8547-46fb-8c71-ef2f3987c7e9" />


## #️⃣ 관련 이슈 (Related Issues)

Close #9 