### PR TITLE
feat: 클립 내용 수정 API 구현 (#31)

### DIFF
--- a/src/apis/clip/controller/handleUpdateClip.js
+++ b/src/apis/clip/controller/handleUpdateClip.js
@@ -1,0 +1,36 @@
+import { createErrorResponse, createSuccessResponse } from '../../../utils/responseFormatter.js';
+import { updateClip } from '../service/updateClip.js';
+
+/**
+ * 클립 수정 컨트롤러
+ * @param {Object} req - Express request 객체
+ * @param {Object} res - Express response 객체
+ */
+export const handleUpdateClip = async (req, res) => {
+  try {
+    const { clipId } = req.params;
+    const userId = req.user?.id; // 인증 미들웨어에서 제공하는 사용자 정보
+
+    // 사용자 인증 확인
+    if (!userId) {
+      const errorResponse = createErrorResponse('UNAUTHORIZED', '인증되지 않은 사용자입니다.');
+      return res.status(401).json(errorResponse);
+    }
+
+    // 요청 본문에서 수정할 필드들 추출
+    const { title, url, tagName, memo } = req.body;
+    const updateFields = { title, url, tagName, memo };
+
+    // 클립 수정 서비스 호출 (소유자 검증 포함)
+    const result = await updateClip(clipId, userId, updateFields);
+
+    // 성공 응답
+    const successResponse = createSuccessResponse(result);
+    res.status(200).json(successResponse);
+  } catch (error) {
+    // 에러 응답
+    const errorResponse = createErrorResponse(error.name, error.message);
+    const statusCode = error.statusCode || 500;
+    res.status(statusCode).json(errorResponse);
+  }
+};

--- a/src/apis/clip/repository/updateClipById.js
+++ b/src/apis/clip/repository/updateClipById.js
@@ -1,0 +1,33 @@
+import { supabase } from '../../../db/supabase-client.js';
+import { CustomError } from '../../../utils/errors.js';
+
+/**
+ * 클립 ID와 사용자 ID를 기반으로 클립을 수정합니다.
+ * @param {number} clipId 수정할 클립의 ID
+ * @param {string} userId 클립 소유자의 사용자 ID
+ * @param {Object} updateData 수정할 데이터
+ * @param {string} [updateData.title] 클립 제목
+ * @param {string} [updateData.url] 클립 URL
+ * @param {string} [updateData.memo] 클립 메모
+ * @param {number} [updateData.tagId] 태그 ID
+ * @returns {Promise<Object>} 수정된 클립의 정보
+ * @throws {CustomError} 클립을 찾을 수 없거나 수정에 실패한 경우
+ */
+export const updateClipById = async (clipId, userId, updateData) => {
+  const { data, error } = await supabase
+    .from('clips')
+    .update(updateData)
+    .eq('id', clipId)
+    .eq('user_id', userId) // 소유자 검증
+    .select('id, title, url, memo, tag_id')
+    .single();
+
+  if (error) {
+    if (error.code === 'PGRST116') {
+      throw new CustomError('CLIP_NOT_FOUND', '수정할 클립을 찾을 수 없습니다.', 404);
+    }
+    throw new CustomError('CLIP_UPDATE_ERROR', '클립 수정 중 오류가 발생했습니다.', 500);
+  }
+
+  return data;
+};

--- a/src/apis/clip/service/updateClip.js
+++ b/src/apis/clip/service/updateClip.js
@@ -1,0 +1,78 @@
+import { CustomError } from '../../../utils/errors.js';
+import { createTag } from '../repository/createTag.js';
+import { findTagByName } from '../repository/findTagByName.js';
+import { updateClipById } from '../repository/updateClipById.js';
+
+/**
+ * 클립을 수정합니다.
+ * @param {number} clipId - 수정할 클립의 고유 ID
+ * @param {string} userId - 클립 소유자의 사용자 ID
+ * @param {Object} updateFields - 수정할 필드들
+ * @param {string} [updateFields.title] - 클립 제목
+ * @param {string} [updateFields.url] - 클립 URL
+ * @param {string} [updateFields.tagName] - 태그 이름
+ * @param {string} [updateFields.memo] - 클립 메모
+ * @returns {Promise<Object>} 수정 성공 메시지
+ * @throws {CustomError} 클립을 찾을 수 없거나 수정에 실패한 경우
+ */
+export const updateClip = async (clipId, userId, updateFields) => {
+  // 클립 ID 유효성 검사
+  if (!clipId || isNaN(clipId) || clipId <= 0) {
+    throw new CustomError('INVALID_CLIP_ID', '유효하지 않은 클립 ID입니다.', 400);
+  }
+
+  // 사용자 ID 유효성 검사
+  if (!userId) {
+    throw new CustomError('INVALID_USER_ID', '유효하지 않은 사용자 ID입니다.', 400);
+  }
+
+  // 수정할 데이터가 없는 경우
+  if (!updateFields || Object.keys(updateFields).length === 0) {
+    throw new CustomError('NO_UPDATE_DATA', '수정할 데이터가 제공되지 않았습니다.', 400);
+  }
+
+  // 유효한 필드만 필터링
+  const validFields = ['title', 'url', 'tagName', 'memo'];
+  const filteredFields = {};
+
+  for (const [key, value] of Object.entries(updateFields)) {
+    if (validFields.includes(key) && value !== undefined && value !== null) {
+      filteredFields[key] = typeof value === 'string' ? value.trim() : value;
+    }
+  }
+
+  if (Object.keys(filteredFields).length === 0) {
+    throw new CustomError('NO_VALID_UPDATE_DATA', '유효한 수정 데이터가 없습니다.', 400);
+  }
+
+  // 태그 처리
+  let tagId = null;
+  if (filteredFields.tagName) {
+    // 기존 태그 찾기
+    const existingTag = await findTagByName(filteredFields.tagName, userId);
+
+    if (existingTag) {
+      tagId = existingTag.id;
+    } else {
+      // 새로운 태그 생성
+      const newTag = await createTag(filteredFields.tagName, userId);
+      tagId = newTag.id;
+    }
+  }
+
+  // 수정할 데이터 준비 (DB 컬럼명으로 변환)
+  const updateData = {};
+  if (filteredFields.title) updateData.title = filteredFields.title;
+  if (filteredFields.url) updateData.url = filteredFields.url;
+  if (filteredFields.memo) updateData.memo = filteredFields.memo;
+  if (tagId) updateData.tag_id = tagId;
+
+  // 클립 수정 실행 (소유자 검증 포함)
+  const updatedClip = await updateClipById(Number(clipId), userId, updateData);
+
+  return {
+    message: '클립이 성공적으로 수정되었습니다.',
+    updatedClipId: updatedClip.id,
+    updatedFields: Object.keys(filteredFields),
+  };
+};

--- a/src/routes/router.js
+++ b/src/routes/router.js
@@ -7,6 +7,7 @@ import { handleCreateClip } from '../apis/clip/controller/handleCreateClip.js';
 import { handleDeleteClip } from '../apis/clip/controller/handleDeleteClip.js';
 import { handleGetAllClips } from '../apis/clip/controller/handleGetAllClips.js';
 import { handleGetClipById } from '../apis/clip/controller/handleGetClipById.js';
+import { handleUpdateClip } from '../apis/clip/controller/handleUpdateClip.js';
 import { conditionalAuth, optionalAuth } from '../middlewares/auth.js';
 
 export const router = (app) => {
@@ -26,6 +27,7 @@ export const router = (app) => {
   // Clip API (인증 필요)
   app.get('/api/clips', handleGetAllClips);
   app.post('/api/clips', handleCreateClip);
+  app.put('/api/clips/:clipId', handleUpdateClip);
   app.delete('/api/clips/:clipId', handleDeleteClip);
 
   // Clip 상세 조회 API (선택적 인증)

--- a/tests/apis/clip/controller/handleUpdateClip.test.js
+++ b/tests/apis/clip/controller/handleUpdateClip.test.js
@@ -1,0 +1,224 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+// Mock service
+jest.unstable_mockModule('../../../../src/apis/clip/service/updateClip.js', () => ({
+  updateClip: jest.fn(),
+}));
+
+// Mock response formatter
+jest.unstable_mockModule('../../../../src/utils/responseFormatter.js', () => ({
+  createSuccessResponse: jest.fn(),
+  createErrorResponse: jest.fn(),
+}));
+
+const { updateClip } = await import('../../../../src/apis/clip/service/updateClip.js');
+const { createSuccessResponse, createErrorResponse } = await import('../../../../src/utils/responseFormatter.js');
+const { handleUpdateClip } = await import('../../../../src/apis/clip/controller/handleUpdateClip.js');
+const { CustomError } = await import('../../../../src/utils/errors.js');
+
+describe('handleUpdateClip Controller 테스트', () => {
+  let mockReq, mockRes;
+  const mockUserId = 'test-user-123';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockReq = {
+      params: { clipId: '1' },
+      user: { id: mockUserId }, // 인증 미들웨어에서 제공하는 사용자 정보
+      body: { title: '수정된 제목', url: 'https://updated.com', memo: '수정된 메모' },
+    };
+
+    mockRes = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
+    };
+  });
+
+  describe('✅ 성공 케이스', () => {
+    test('클립 수정을 성공적으로 처리한다 (소유자 검증 포함)', async () => {
+      const mockServiceResult = {
+        message: '클립이 성공적으로 수정되었습니다.',
+        updatedClipId: 1,
+        updatedFields: ['title', 'url', 'memo'],
+      };
+      const mockSuccessResponse = { status: 'SUCCESS', data: mockServiceResult };
+
+      updateClip.mockResolvedValue(mockServiceResult);
+      createSuccessResponse.mockReturnValue(mockSuccessResponse);
+
+      await handleUpdateClip(mockReq, mockRes);
+
+      expect(updateClip).toHaveBeenCalledWith('1', mockUserId, {
+        title: '수정된 제목',
+        url: 'https://updated.com',
+        tagName: undefined,
+        memo: '수정된 메모',
+      });
+      expect(createSuccessResponse).toHaveBeenCalledWith(mockServiceResult);
+      expect(mockRes.status).toHaveBeenCalledWith(200);
+      expect(mockRes.json).toHaveBeenCalledWith(mockSuccessResponse);
+    });
+
+    test('부분 필드 수정 요청을 올바르게 처리한다', async () => {
+      mockReq.body = { title: '새 제목' };
+      const mockServiceResult = {
+        message: '클립이 성공적으로 수정되었습니다.',
+        updatedClipId: 1,
+        updatedFields: ['title'],
+      };
+
+      updateClip.mockResolvedValue(mockServiceResult);
+      createSuccessResponse.mockReturnValue({ status: 'SUCCESS', data: mockServiceResult });
+
+      await handleUpdateClip(mockReq, mockRes);
+
+      expect(updateClip).toHaveBeenCalledWith('1', mockUserId, {
+        title: '새 제목',
+        url: undefined,
+        tagName: undefined,
+        memo: undefined,
+      });
+    });
+
+    test('태그명 포함 수정 요청을 처리한다', async () => {
+      mockReq.body = { title: '제목', tagName: '새태그' };
+      const mockServiceResult = {
+        message: '클립이 성공적으로 수정되었습니다.',
+        updatedClipId: 1,
+        updatedFields: ['title', 'tagName'],
+      };
+
+      updateClip.mockResolvedValue(mockServiceResult);
+      createSuccessResponse.mockReturnValue({ status: 'SUCCESS', data: mockServiceResult });
+
+      await handleUpdateClip(mockReq, mockRes);
+
+      expect(updateClip).toHaveBeenCalledWith('1', mockUserId, {
+        title: '제목',
+        url: undefined,
+        tagName: '새태그',
+        memo: undefined,
+      });
+    });
+  });
+
+  describe('❌ 에러 케이스', () => {
+    test('사용자 인증 정보가 없으면 401 에러를 반환한다', async () => {
+      mockReq.user = null; // 인증 정보 없음
+      const mockErrorResponse = { status: 'ERROR', errorCode: 'UNAUTHORIZED' };
+      createErrorResponse.mockReturnValue(mockErrorResponse);
+
+      await handleUpdateClip(mockReq, mockRes);
+
+      expect(createErrorResponse).toHaveBeenCalledWith('UNAUTHORIZED', '인증되지 않은 사용자입니다.');
+      expect(mockRes.status).toHaveBeenCalledWith(401);
+      expect(mockRes.json).toHaveBeenCalledWith(mockErrorResponse);
+      expect(updateClip).not.toHaveBeenCalled();
+    });
+
+    test('사용자 ID가 없으면 401 에러를 반환한다', async () => {
+      mockReq.user = { id: undefined }; // ID 없음
+      const mockErrorResponse = { status: 'ERROR', errorCode: 'UNAUTHORIZED' };
+      createErrorResponse.mockReturnValue(mockErrorResponse);
+
+      await handleUpdateClip(mockReq, mockRes);
+
+      expect(createErrorResponse).toHaveBeenCalledWith('UNAUTHORIZED', '인증되지 않은 사용자입니다.');
+      expect(mockRes.status).toHaveBeenCalledWith(401);
+      expect(mockRes.json).toHaveBeenCalledWith(mockErrorResponse);
+    });
+
+    test('서비스에서 400 에러 발생 시 400 상태코드로 응답한다', async () => {
+      const mockError = new CustomError('NO_UPDATE_DATA', '수정할 데이터가 제공되지 않았습니다.', 400);
+      const mockErrorResponse = { status: 'ERROR', errorCode: 'NO_UPDATE_DATA' };
+
+      updateClip.mockRejectedValue(mockError);
+      createErrorResponse.mockReturnValue(mockErrorResponse);
+
+      await handleUpdateClip(mockReq, mockRes);
+
+      expect(createErrorResponse).toHaveBeenCalledWith('NO_UPDATE_DATA', '수정할 데이터가 제공되지 않았습니다.');
+      expect(mockRes.status).toHaveBeenCalledWith(400);
+      expect(mockRes.json).toHaveBeenCalledWith(mockErrorResponse);
+    });
+
+    test('서비스에서 404 에러 발생 시 404 상태코드로 응답한다', async () => {
+      const mockError = new CustomError('CLIP_NOT_FOUND', '수정할 클립을 찾을 수 없습니다.', 404);
+      const mockErrorResponse = { status: 'ERROR', errorCode: 'CLIP_NOT_FOUND' };
+
+      updateClip.mockRejectedValue(mockError);
+      createErrorResponse.mockReturnValue(mockErrorResponse);
+
+      await handleUpdateClip(mockReq, mockRes);
+
+      expect(createErrorResponse).toHaveBeenCalledWith('CLIP_NOT_FOUND', '수정할 클립을 찾을 수 없습니다.');
+      expect(mockRes.status).toHaveBeenCalledWith(404);
+      expect(mockRes.json).toHaveBeenCalledWith(mockErrorResponse);
+    });
+
+    test('예상치 못한 에러 발생 시 500 상태코드로 응답한다', async () => {
+      const mockError = new Error('예상치 못한 에러');
+      const mockErrorResponse = { status: 'ERROR', errorCode: 'Error' };
+
+      updateClip.mockRejectedValue(mockError);
+      createErrorResponse.mockReturnValue(mockErrorResponse);
+
+      await handleUpdateClip(mockReq, mockRes);
+
+      expect(createErrorResponse).toHaveBeenCalledWith('Error', '예상치 못한 에러');
+      expect(mockRes.status).toHaveBeenCalledWith(500);
+      expect(mockRes.json).toHaveBeenCalledWith(mockErrorResponse);
+    });
+  });
+
+  describe('🧪 HTTP 요청/응답 처리', () => {
+    test('req.params에서 clipId를 올바르게 추출한다', async () => {
+      mockReq.params.clipId = '999';
+      const mockServiceResult = { message: '수정됨', updatedClipId: 999, updatedFields: ['title'] };
+
+      updateClip.mockResolvedValue(mockServiceResult);
+      createSuccessResponse.mockReturnValue({ status: 'SUCCESS' });
+
+      await handleUpdateClip(mockReq, mockRes);
+
+      expect(updateClip).toHaveBeenCalledWith('999', mockUserId, expect.any(Object));
+    });
+
+    test('req.user에서 사용자 ID를 올바르게 추출한다', async () => {
+      const differentUserId = 'different-user-456';
+      mockReq.user.id = differentUserId;
+
+      const mockServiceResult = { message: '수정됨', updatedClipId: 1, updatedFields: ['title'] };
+      updateClip.mockResolvedValue(mockServiceResult);
+      createSuccessResponse.mockReturnValue({ status: 'SUCCESS' });
+
+      await handleUpdateClip(mockReq, mockRes);
+
+      expect(updateClip).toHaveBeenCalledWith('1', differentUserId, expect.any(Object));
+    });
+
+    test('req.body에서 수정 필드들을 올바르게 추출한다', async () => {
+      mockReq.body = {
+        title: '새 제목',
+        url: 'https://new.com',
+        tagName: '새태그',
+        memo: '새 메모',
+        invalidField: '무시됨',
+      };
+
+      const mockServiceResult = { message: '수정됨', updatedClipId: 1, updatedFields: [] };
+      updateClip.mockResolvedValue(mockServiceResult);
+      createSuccessResponse.mockReturnValue({ status: 'SUCCESS' });
+
+      await handleUpdateClip(mockReq, mockRes);
+
+      expect(updateClip).toHaveBeenCalledWith('1', mockUserId, {
+        title: '새 제목',
+        url: 'https://new.com',
+        tagName: '새태그',
+        memo: '새 메모',
+      });
+    });
+  });
+});

--- a/tests/apis/clip/repository/updateClipById.test.js
+++ b/tests/apis/clip/repository/updateClipById.test.js
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+// Mock Supabase client
+jest.unstable_mockModule('../../../../src/db/supabase-client.js', () => ({
+  supabase: {
+    from: jest.fn(),
+  },
+}));
+
+const { supabase } = await import('../../../../src/db/supabase-client.js');
+const { updateClipById } = await import('../../../../src/apis/clip/repository/updateClipById.js');
+const { CustomError } = await import('../../../../src/utils/errors.js');
+
+describe('updateClipById Repository 테스트', () => {
+  let mockFrom, mockUpdate, mockEq, mockSelect, mockSingle;
+  const mockUserId = 'test-user-123';
+  const mockUpdateData = { title: '수정된 제목', url: 'https://updated.com', memo: '수정된 메모' };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Supabase 체인 메서드 모킹
+    mockSingle = jest.fn();
+    mockSelect = jest.fn(() => ({ single: mockSingle }));
+    mockEq = jest.fn(() => ({ eq: mockEq, select: mockSelect }));
+    mockUpdate = jest.fn(() => ({ eq: mockEq }));
+    mockFrom = jest.fn(() => ({ update: mockUpdate }));
+
+    supabase.from = mockFrom;
+  });
+
+  test('클립을 성공적으로 수정한다 (소유자 검증 포함)', async () => {
+    const mockUpdatedClip = {
+      id: 1,
+      title: '수정된 제목',
+      url: 'https://updated.com',
+      memo: '수정된 메모',
+      tag_id: 2,
+    };
+    mockSingle.mockResolvedValue({ data: mockUpdatedClip, error: null });
+
+    const result = await updateClipById(1, mockUserId, mockUpdateData);
+
+    expect(mockFrom).toHaveBeenCalledWith('clips');
+    expect(mockUpdate).toHaveBeenCalledWith(mockUpdateData);
+    expect(mockEq).toHaveBeenCalledWith('id', 1);
+    expect(mockEq).toHaveBeenCalledWith('user_id', mockUserId);
+    expect(mockSelect).toHaveBeenCalledWith('id, title, url, memo, tag_id');
+    expect(mockSingle).toHaveBeenCalled();
+    expect(result).toEqual(mockUpdatedClip);
+  });
+
+  test('존재하지 않는 클립 또는 타인 소유 클립 수정 시 404 에러를 발생시킨다', async () => {
+    const mockError = { code: 'PGRST116', message: 'No rows found' };
+    mockSingle.mockResolvedValue({ data: null, error: mockError });
+
+    await expect(updateClipById(999, mockUserId, mockUpdateData)).rejects.toThrow(
+      new CustomError('CLIP_NOT_FOUND', '수정할 클립을 찾을 수 없습니다.', 404)
+    );
+  });
+
+  test('데이터베이스 에러 발생 시 500 에러를 발생시킨다', async () => {
+    const mockError = { code: 'OTHER_ERROR', message: 'Database connection failed' };
+    mockSingle.mockResolvedValue({ data: null, error: mockError });
+
+    await expect(updateClipById(1, mockUserId, mockUpdateData)).rejects.toThrow(
+      new CustomError('CLIP_UPDATE_ERROR', '클립 수정 중 오류가 발생했습니다.', 500)
+    );
+  });
+
+  test('정상적인 clipId, userId, updateData로 올바른 쿼리가 실행된다', async () => {
+    const mockUpdatedClip = { id: 42, title: '테스트 제목', url: 'https://test.com', memo: 'test', tag_id: 1 };
+    mockSingle.mockResolvedValue({ data: mockUpdatedClip, error: null });
+
+    await updateClipById(42, mockUserId, { title: '테스트 제목' });
+
+    expect(mockUpdate).toHaveBeenCalledWith({ title: '테스트 제목' });
+    expect(mockEq).toHaveBeenCalledWith('id', 42);
+    expect(mockEq).toHaveBeenCalledWith('user_id', mockUserId);
+  });
+
+  test('부분 데이터 수정도 정상적으로 처리한다', async () => {
+    const partialUpdate = { title: '새 제목' };
+    const mockUpdatedClip = { id: 1, title: '새 제목', url: 'https://old.com', memo: 'old memo', tag_id: 1 };
+    mockSingle.mockResolvedValue({ data: mockUpdatedClip, error: null });
+
+    const result = await updateClipById(1, mockUserId, partialUpdate);
+
+    expect(mockUpdate).toHaveBeenCalledWith(partialUpdate);
+    expect(result).toEqual(mockUpdatedClip);
+  });
+});

--- a/tests/apis/clip/service/updateClip.test.js
+++ b/tests/apis/clip/service/updateClip.test.js
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+// Mock repository
+jest.unstable_mockModule('../../../../src/apis/clip/repository/updateClipById.js', () => ({
+  updateClipById: jest.fn(),
+}));
+
+jest.unstable_mockModule('../../../../src/apis/clip/repository/findTagByName.js', () => ({
+  findTagByName: jest.fn(),
+}));
+
+jest.unstable_mockModule('../../../../src/apis/clip/repository/createTag.js', () => ({
+  createTag: jest.fn(),
+}));
+
+const { updateClipById } = await import('../../../../src/apis/clip/repository/updateClipById.js');
+const { findTagByName } = await import('../../../../src/apis/clip/repository/findTagByName.js');
+const { createTag } = await import('../../../../src/apis/clip/repository/createTag.js');
+const { updateClip } = await import('../../../../src/apis/clip/service/updateClip.js');
+const { CustomError } = await import('../../../../src/utils/errors.js');
+
+describe('updateClip Service 테스트', () => {
+  const mockUserId = 'test-user-123';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('✅ 성공 케이스', () => {
+    test('유효한 clipId와 userId, 기본 필드로 클립을 성공적으로 수정한다', async () => {
+      const mockUpdatedClip = {
+        id: 1,
+        title: '수정된 제목',
+        url: 'https://updated.com',
+        memo: 'updated memo',
+        tag_id: 1,
+      };
+      updateClipById.mockResolvedValue(mockUpdatedClip);
+
+      const updateFields = { title: '수정된 제목', url: 'https://updated.com', memo: 'updated memo' };
+      const result = await updateClip('1', mockUserId, updateFields);
+
+      expect(updateClipById).toHaveBeenCalledWith(1, mockUserId, {
+        title: '수정된 제목',
+        url: 'https://updated.com',
+        memo: 'updated memo',
+      });
+      expect(result).toEqual({
+        message: '클립이 성공적으로 수정되었습니다.',
+        updatedClipId: 1,
+        updatedFields: ['title', 'url', 'memo'],
+      });
+    });
+
+    test('기존 태그로 클립을 수정한다', async () => {
+      const existingTag = { id: 5, name: '기존태그' };
+      const mockUpdatedClip = { id: 1, title: '제목', url: 'https://test.com', memo: 'memo', tag_id: 5 };
+
+      findTagByName.mockResolvedValue(existingTag);
+      updateClipById.mockResolvedValue(mockUpdatedClip);
+
+      const updateFields = { tagName: '기존태그' };
+      const result = await updateClip('1', mockUserId, updateFields);
+
+      expect(findTagByName).toHaveBeenCalledWith('기존태그', mockUserId);
+      expect(createTag).not.toHaveBeenCalled();
+      expect(updateClipById).toHaveBeenCalledWith(1, mockUserId, { tag_id: 5 });
+      expect(result.updatedFields).toContain('tagName');
+    });
+
+    test('새로운 태그로 클립을 수정한다', async () => {
+      const newTag = { id: 10, name: '새태그' };
+      const mockUpdatedClip = { id: 1, title: '제목', url: 'https://test.com', memo: 'memo', tag_id: 10 };
+
+      findTagByName.mockResolvedValue(null); // 태그가 존재하지 않음
+      createTag.mockResolvedValue(newTag);
+      updateClipById.mockResolvedValue(mockUpdatedClip);
+
+      const updateFields = { tagName: '새태그' };
+      await updateClip('1', mockUserId, updateFields);
+
+      expect(findTagByName).toHaveBeenCalledWith('새태그', mockUserId);
+      expect(createTag).toHaveBeenCalledWith('새태그', mockUserId);
+      expect(updateClipById).toHaveBeenCalledWith(1, mockUserId, { tag_id: 10 });
+    });
+
+    test('부분 필드 수정도 정상적으로 처리한다', async () => {
+      const mockUpdatedClip = { id: 42, title: '새 제목', url: 'old-url', memo: 'old-memo', tag_id: 1 };
+      updateClipById.mockResolvedValue(mockUpdatedClip);
+
+      const updateFields = { title: '새 제목' };
+      const result = await updateClip(42, mockUserId, updateFields);
+
+      expect(updateClipById).toHaveBeenCalledWith(42, mockUserId, { title: '새 제목' });
+      expect(result.updatedFields).toEqual(['title']);
+    });
+  });
+
+  describe('❌ 에러 케이스', () => {
+    test('clipId가 없으면 400 에러를 발생시킨다', async () => {
+      await expect(updateClip(null, mockUserId, { title: '제목' })).rejects.toThrow(
+        new CustomError('INVALID_CLIP_ID', '유효하지 않은 클립 ID입니다.', 400)
+      );
+      await expect(updateClip(undefined, mockUserId, { title: '제목' })).rejects.toThrow(
+        new CustomError('INVALID_CLIP_ID', '유효하지 않은 클립 ID입니다.', 400)
+      );
+    });
+
+    test('userId가 없으면 400 에러를 발생시킨다', async () => {
+      await expect(updateClip('1', null, { title: '제목' })).rejects.toThrow(
+        new CustomError('INVALID_USER_ID', '유효하지 않은 사용자 ID입니다.', 400)
+      );
+      await expect(updateClip('1', '', { title: '제목' })).rejects.toThrow(
+        new CustomError('INVALID_USER_ID', '유효하지 않은 사용자 ID입니다.', 400)
+      );
+    });
+
+    test('수정할 데이터가 없으면 400 에러를 발생시킨다', async () => {
+      await expect(updateClip('1', mockUserId, {})).rejects.toThrow(
+        new CustomError('NO_UPDATE_DATA', '수정할 데이터가 제공되지 않았습니다.', 400)
+      );
+      await expect(updateClip('1', mockUserId, null)).rejects.toThrow(
+        new CustomError('NO_UPDATE_DATA', '수정할 데이터가 제공되지 않았습니다.', 400)
+      );
+    });
+
+    test('유효하지 않은 필드만 있으면 400 에러를 발생시킨다', async () => {
+      await expect(updateClip('1', mockUserId, { invalidField: '값' })).rejects.toThrow(
+        new CustomError('NO_VALID_UPDATE_DATA', '유효한 수정 데이터가 없습니다.', 400)
+      );
+    });
+
+    test('유효하지 않은 clipId 형식이면 400 에러를 발생시킨다', async () => {
+      await expect(updateClip('abc', mockUserId, { title: '제목' })).rejects.toThrow(
+        new CustomError('INVALID_CLIP_ID', '유효하지 않은 클립 ID입니다.', 400)
+      );
+      await expect(updateClip('0', mockUserId, { title: '제목' })).rejects.toThrow(
+        new CustomError('INVALID_CLIP_ID', '유효하지 않은 클립 ID입니다.', 400)
+      );
+    });
+
+    test('Repository에서 에러가 발생하면 에러를 전파한다', async () => {
+      const mockError = new CustomError('CLIP_NOT_FOUND', '클립을 찾을 수 없습니다.', 404);
+      updateClipById.mockRejectedValue(mockError);
+
+      await expect(updateClip('1', mockUserId, { title: '제목' })).rejects.toThrow(mockError);
+    });
+  });
+
+  describe('🧪 데이터 처리 테스트', () => {
+    test('문자열 공백을 제거한다', async () => {
+      const mockUpdatedClip = { id: 1, title: '제목', url: 'https://test.com', memo: '메모', tag_id: 1 };
+      updateClipById.mockResolvedValue(mockUpdatedClip);
+
+      const updateFields = { title: '  제목  ', url: '  https://test.com  ', memo: '  메모  ' };
+      await updateClip('1', mockUserId, updateFields);
+
+      expect(updateClipById).toHaveBeenCalledWith(1, mockUserId, {
+        title: '제목',
+        url: 'https://test.com',
+        memo: '메모',
+      });
+    });
+
+    test('null과 undefined 값을 필터링한다', async () => {
+      const mockUpdatedClip = { id: 1, title: '제목', url: 'old-url', memo: 'old-memo', tag_id: 1 };
+      updateClipById.mockResolvedValue(mockUpdatedClip);
+
+      const updateFields = { title: '제목', url: null, memo: undefined };
+      await updateClip('1', mockUserId, updateFields);
+
+      expect(updateClipById).toHaveBeenCalledWith(1, mockUserId, { title: '제목' });
+    });
+  });
+});


### PR DESCRIPTION
## 📝 요약 (Summary)

Swagger 문서 스펙에 따라 클립 내용 수정 API를 3-layer 아키텍처로 구현하였습니다. 사용자가 특정 클립 ID를 통해 자신의 클립 내용(제목, URL, 태그, 메모)을 안전하게 수정할 수 있는 기능을 제공합니다.

## ✅ 주요 변경 사항 (Key Changes)

• PUT /api/clips/:clipId 엔드포인트 추가
• 3-layer 아키텍처 완전 구현 (Repository → Service → Controller)  
• 소유자 검증 로직 포함 (user_id 기반 보안 체크)
• 태그 처리: 기존 태그 재사용 및 새 태그 자동 생성
• 부분 필드 수정 지원 (title, url, tagName, memo)
• 체계적인 에러 처리 (404, 400, 500 상태 코드)
• 유효성 검사 및 데이터 정제 (공백 제거, null/undefined 필터링)
• 단위 테스트 작성 (Repository/Service/Controller 각 계층)

## 💻 상세 구현 내용 (Implementation Details)

### 🏗️ Repository Layer (`updateClipById.js`)

• Supabase를 활용한 DB 클립 수정 쿼리 구현
• 소유자 검증을 위한 user_id 조건 포함
• 수정된 클립의 기본 정보 (id, title, url, memo, tag_id) 반환
• PGRST116 에러 코드를 통한 404 처리

```javascript
const { data, error } = await supabase
  .from('clips')
  .update(updateData)
  .eq('id', clipId)
  .eq('user_id', userId) // 소유자 검증
  .select('id, title, url, memo, tag_id')
  .single();
```

### 🔧 Service Layer (`updateClip.js`)

• clipId, userId 유효성 검사 (숫자, 양수 확인)
• 수정 필드 유효성 검사 및 데이터 정제
• 태그 처리 로직: 기존 태그 재사용 또는 새 태그 자동 생성
• 부분 필드 수정 지원 (일부 필드만 수정 가능)
• 성공 시 수정된 필드 목록 포함한 사용자 친화적 메시지 반환

```javascript
// 태그 처리 로직
if (filteredFields.tagName) {
  const existingTag = await findTagByName(filteredFields.tagName, userId);
  
  if (existingTag) {
    tagId = existingTag.id;
  } else {
    const newTag = await createTag(filteredFields.tagName, userId);
    tagId = newTag.id;
  }
}
```

### 🌐 Controller Layer (`handleUpdateClip.js`)

• Express req.params에서 clipId 추출
• req.user에서 사용자 인증 정보 확인
• req.body에서 수정 필드들 추출 (title, url, tagName, memo)
• 표준화된 성공/에러 응답 포맷 사용
• HTTP 상태 코드 자동 매핑 (200, 401, 400, 404, 500)

### 🛣️ Router 연동

• Express PUT 메서드 라우트 등록
• 기존 인증 미들웨어와 연동
• RESTful API 패턴 준수

```javascript
app.put('/api/clips/:clipId', handleUpdateClip);
```

## 🚀 트러블 슈팅 (Trouble Shooting)

### 1. 태그 처리 로직 설계

**문제**: 클립 수정 시 새로운 태그명이 제공될 때, 기존 태그를 재사용할지 새로 생성할지 결정 필요
**해결**: 먼저 기존 태그를 조회하고, 없으면 새로 생성하는 2단계 로직으로 구현

### 2. 부분 필드 수정 지원

**문제**: 모든 필드를 필수로 받을지, 제공된 필드만 수정할지 결정 필요
**해결**: 유효한 필드만 필터링하여 부분 수정을 지원하도록 구현

### 3. 소유자 검증 보안

**문제**: 클립 수정 시 다른 사용자의 클립을 수정하는 보안 취약점 방지 필요
**해결**: Repository 레벨에서 user_id 조건을 포함하여 DB 차원에서 소유권 검증

## ⚠️ 알려진 이슈 및 참고 사항 (Known Issues & Notes)

### 테스트 실행 이슈

• 모든 단위 테스트가 성공적으로 통과
• Repository(5개), Service(12개), Controller(11개) 총 28개 테스트 케이스
• 로컬 서버에서 정상적으로 동작 확인됨

### 성능 고려사항

• 태그 처리 시 2번의 DB 쿼리 발생 가능 (기존 태그 조회 + 새 태그 생성)
• 추후 태그 캐싱 또는 배치 처리 고려 가능

### API 동작 특징

• 수정할 데이터가 제공되지 않으면 400 에러 반환
• 존재하지 않는 클립 또는 타인 소유 클립 수정 시 404 에러
• 태그명만 제공된 경우에도 정상 처리 (기존 태그 재사용 또는 새 태그 생성)

## 📸 스크린샷 (Screenshots)

**Swagger API 문서:**

• PUT /api/clips/{clipId} 엔드포인트 정상 표시
• 200, 400, 404 응답 스키마 정의 완료
• 요청 본문 스키마 정의: title, url, tagName, memo 필드

**로컬 서버 실행:**

```
Server is running on port 8081
[nodemon] clean exit - waiting for changes before restart
```

**테스트 실행 결과:**

```
✅ Repository 테스트: 5/5 passed
✅ Service 테스트: 12/12 passed  
✅ Controller 테스트: 11/11 passed
총 28개 테스트 케이스 성공
```

## #️⃣ 관련 이슈 (Related Issues)

• feat#31-update-clip 브랜치로 개발 진행
• Swagger 문서 스펙 기반 구현
• 클립 삭제 API(#28)와 일관된 아키텍처 적용

## 🧪 테스트 커버리지

### Repository Layer 테스트

• ✅ 소유자 검증 포함 정상 클립 수정 성공
• ✅ 존재하지 않는 클립 또는 타인 소유 클립 404 에러
• ✅ 데이터베이스 에러 500 처리
• ✅ 올바른 Supabase 쿼리 호출 검증
• ✅ 부분 데이터 수정 처리

### Service Layer 테스트

• ✅ 유효한 clipId, userId로 성공 처리
• ✅ 기존 태그 재사용 로직 검증
• ✅ 새로운 태그 자동 생성 로직 검증
• ✅ 부분 필드 수정 지원 확인
• ✅ 유효성 검사 (clipId, userId, updateData)
• ✅ 데이터 정제 (공백 제거, null 필터링)
• ✅ Repository 에러 전파 확인
• ✅ 경계값 테스트 (유효하지 않은 필드, 빈 데이터)

### Controller Layer 테스트

• ✅ HTTP 요청/응답 처리
• ✅ params에서 clipId 추출
• ✅ req.user에서 사용자 ID 추출
• ✅ req.body에서 수정 필드들 추출
• ✅ 성공/에러 응답 포맷팅
• ✅ HTTP 상태 코드 자동 매핑
• ✅ 인증 실패 401 에러 처리
• ✅ 400/404/500 에러 시나리오

## 🤖 Copilot 리뷰 가이드라인

**리뷰어 및 Copilot에게 요청사항:**
- [x] 모든 리뷰는 **한국어**로 작성해주세요
- [x] Controller → Service → Repository 패턴 준수 여부 확인
- [x] CustomError 및 responseFormatter 사용 여부 체크
- [x] 파일 명명 규칙 (`handleUpdateClip.js`, `updateClip.js`) 확인
- [x] ES modules import에서 `.js` 확장자 포함 여부 확인

**특별히 검토해주세요:**
- [x] 보안: 소유자 검증 로직 구현 - user_id 기반 DB 레벨 검증
- [x] 에러 처리: CustomError로 체계적 처리 (400, 404, 500)
- [x] 코드 일관성: 클립 삭제 API와 동일한 패턴 적용

**추가 리뷰 포인트:**
• 🔍 태그 처리 로직의 효율성 검토 (기존 태그 재사용 vs 새 태그 생성)
• 🔍 부분 필드 수정 로직의 완전성 검토
• 🔍 데이터 유효성 검사 및 정제 로직 검토
• 🔍 소유자 검증의 보안성 및 완전성 검토

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 클립 수정 API(PUT /api/clips/:clipId) 추가: 제목, URL, 메모, 태그명을 개별 또는 부분 업데이트 가능.
  - 태그명이 없을 경우 자동 생성 후 클립에 연결.
  - 인증 필요: 인증 누락 시 401, 권한/존재하지 않는 리소스는 404 등 일관된 상태 코드와 응답 제공.

- 테스트
  - 컨트롤러, 서비스, 리포지토리 전 영역에 대한 단위 테스트 추가로 정상/에러/부분 업데이트/태그 처리 시나리오 검증.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->